### PR TITLE
Recursive goal description parsing

### DIFF
--- a/lib/parsing/ast.hpp
+++ b/lib/parsing/ast.hpp
@@ -71,16 +71,13 @@ namespace ast {
     using Term = x3::variant<Name, Variable>;
 
     struct GoalDescription;
+    struct ConnectedSentence;
 
-    struct ConnectedSentence {
-        //std::string connector;
-        std::vector<x3::forward_ast<GoalDescription>> args;
-    };
 
     struct GoalDescriptionValue
         : x3::variant<Nil,
                       AtomicFormula<Term>,
-                      //ConnectedSentence,
+                      x3::forward_ast<ConnectedSentence>,
                       x3::forward_ast<GoalDescription>> {
         using base_type::base_type;
         using base_type::operator=;
@@ -91,6 +88,10 @@ namespace ast {
         GoalDescriptionValue value;
     };
 
+    struct ConnectedSentence {
+        //std::string connector;
+        std::vector<GoalDescriptionValue> args;
+    };
 
     struct Domain : x3::position_tagged {
         Name name;

--- a/lib/parsing/ast.hpp
+++ b/lib/parsing/ast.hpp
@@ -3,8 +3,8 @@
 #include <boost/fusion/include/io.hpp>
 #include <boost/spirit/home/x3.hpp>
 #include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
-#include <boost/spirit/home/x3/support/ast/variant.hpp>
-#include <boost/variant/recursive_variant.hpp>
+//#include <boost/spirit/home/x3/support/ast/variant.hpp>
+#include <boost/variant/recursive_wrapper.hpp>
 #include <iostream>
 #include <string>
 #include <tuple>
@@ -36,7 +36,11 @@ namespace ast {
         std::unordered_set<PrimitiveType, PrimitiveType::hash> primitive_types;
     };
 
-    using Type = x3::variant<PrimitiveType, EitherType>;
+    using Type = boost::variant<PrimitiveType, EitherType>;
+    //struct Type : x3::variant<PrimitiveType, EitherType> {
+        //using base_type::base_type;
+        //using base_type::operator=;
+    //};
 
     template <class T> using ImplicitlyTypedList = std::vector<T>;
 
@@ -68,29 +72,29 @@ namespace ast {
         std::vector<T> args;
     };
 
-    using Term = x3::variant<Name, Variable>;
+    using Term = boost::variant<Name, Variable>;
 
-    struct GoalDescription;
     struct ConnectedSentence;
 
+    //using GoalDescription = std::string;
+    typedef boost::variant<
+            Nil
+          , AtomicFormula<Term>
+          , boost::recursive_wrapper<ConnectedSentence>
+    > GoalDescription;
+    //struct GoalDescription
+        //: x3::variant<
+          //Nil,
+          //AtomicFormula<Term>,
+          //x3::forward_ast<ConnectedSentence>
+                      //> {
+        //using base_type::base_type;
+        //using base_type::operator=;
+    //};
 
-    struct GoalDescriptionValue
-        : x3::variant<Nil,
-                      AtomicFormula<Term>,
-                      x3::forward_ast<ConnectedSentence>,
-                      x3::forward_ast<GoalDescription>> {
-        using base_type::base_type;
-        using base_type::operator=;
-    };
-
-
-    struct GoalDescription {
-        GoalDescriptionValue value;
-    };
 
     struct ConnectedSentence {
-        //std::string connector;
-        std::vector<GoalDescriptionValue> args;
+        std::vector<GoalDescription> args;
     };
 
     struct Domain : x3::position_tagged {

--- a/lib/parsing/ast.hpp
+++ b/lib/parsing/ast.hpp
@@ -37,10 +37,6 @@ namespace ast {
     };
 
     using Type = boost::variant<PrimitiveType, EitherType>;
-    //struct Type : x3::variant<PrimitiveType, EitherType> {
-        //using base_type::base_type;
-        //using base_type::operator=;
-    //};
 
     template <class T> using ImplicitlyTypedList = std::vector<T>;
 
@@ -60,7 +56,7 @@ namespace ast {
 
     struct AtomicFormulaSkeleton : x3::position_tagged {
         Predicate predicate;
-        TypedList<Variable> args;
+        TypedList<Variable> variables;
     };
 
     struct Nil {
@@ -72,29 +68,38 @@ namespace ast {
         std::vector<T> args;
     };
 
-    using Term = boost::variant<Name, Variable>;
+    using Term = boost::variant<Constant, Variable>;
 
-    struct ConnectedSentence;
+    // Forward declare classes in order to work with Boost's recursive_wrapper
+    struct AndSentence;
+    struct OrSentence;
+    struct NotSentence;
+    struct ImplySentence;
 
-    //using GoalDescription = std::string;
-    typedef boost::variant<
-            Nil
-          , AtomicFormula<Term>
-          , boost::recursive_wrapper<ConnectedSentence>
-    > GoalDescription;
-    //struct GoalDescription
-        //: x3::variant<
-          //Nil,
-          //AtomicFormula<Term>,
-          //x3::forward_ast<ConnectedSentence>
-                      //> {
-        //using base_type::base_type;
-        //using base_type::operator=;
-    //};
+    using Sentence = boost::variant<Nil,
+                                    AtomicFormula<Term>,
+                                    boost::recursive_wrapper<AndSentence>,
+                                    boost::recursive_wrapper<OrSentence>,
+                                    boost::recursive_wrapper<NotSentence>,
+                                    boost::recursive_wrapper<ImplySentence>>;
 
+    // TODO add quantified sentences
 
-    struct ConnectedSentence {
-        std::vector<GoalDescription> args;
+    struct AndSentence {
+        std::vector<Sentence> sentences;
+    };
+
+    struct OrSentence {
+        std::vector<Sentence> sentences;
+    };
+
+    struct NotSentence {
+        Sentence sentence;
+    };
+
+    struct ImplySentence {
+        Sentence sentence1;
+        Sentence sentence2;
     };
 
     struct Domain : x3::position_tagged {
@@ -116,11 +121,6 @@ namespace ast {
     // struct Action : x3::position_tagged {
     // Name name;
     // std::vector<Variable> parameters;
-    //};
-
-    // template <class T> struct AtomicFormula {
-    // Name predicate;
-    // std::vector<T> args;
     //};
 
     using boost::fusion::operator<<;

--- a/lib/parsing/ast_adapted.hpp
+++ b/lib/parsing/ast_adapted.hpp
@@ -26,11 +26,14 @@ BOOST_FUSION_ADAPT_STRUCT(ast::TypedList<ast::Variable>,
                           implicitly_typed_list)
 
 BOOST_FUSION_ADAPT_STRUCT(ast::Predicate, name)
-BOOST_FUSION_ADAPT_STRUCT(ast::AtomicFormulaSkeleton, predicate, args)
+BOOST_FUSION_ADAPT_STRUCT(ast::AtomicFormulaSkeleton, predicate, variables)
 BOOST_FUSION_ADAPT_STRUCT(ast::AtomicFormula<ast::Term>, predicate, args)
 
 BOOST_FUSION_ADAPT_STRUCT(ast::Nil)
-BOOST_FUSION_ADAPT_STRUCT(ast::ConnectedSentence, args)
+BOOST_FUSION_ADAPT_STRUCT(ast::AndSentence, sentences)
+BOOST_FUSION_ADAPT_STRUCT(ast::OrSentence, sentences)
+BOOST_FUSION_ADAPT_STRUCT(ast::NotSentence, sentence)
+BOOST_FUSION_ADAPT_STRUCT(ast::ImplySentence, sentence1, sentence2)
 
 BOOST_FUSION_ADAPT_STRUCT(ast::Domain, name, requirements, types, constants, predicates)
 BOOST_FUSION_ADAPT_STRUCT(ast::Problem, name, domain_name, requirements, objects)

--- a/lib/parsing/ast_adapted.hpp
+++ b/lib/parsing/ast_adapted.hpp
@@ -31,9 +31,6 @@ BOOST_FUSION_ADAPT_STRUCT(ast::AtomicFormula<ast::Term>, predicate, args)
 
 BOOST_FUSION_ADAPT_STRUCT(ast::Nil)
 BOOST_FUSION_ADAPT_STRUCT(ast::ConnectedSentence, args)
-BOOST_FUSION_ADAPT_STRUCT(ast::GoalDescription, value)
 
 BOOST_FUSION_ADAPT_STRUCT(ast::Domain, name, requirements, types, constants, predicates)
 BOOST_FUSION_ADAPT_STRUCT(ast::Problem, name, domain_name, requirements, objects)
-
-// BOOST_FUSION_ADAPT_STRUCT(ast::Action, name, parameters)

--- a/lib/parsing/domain.cpp
+++ b/lib/parsing/domain.cpp
@@ -17,7 +17,7 @@ namespace parser {
 
     BOOST_SPIRIT_INSTANTIATE(atomic_formula_terms_type, iterator_type, context_type);
     BOOST_SPIRIT_INSTANTIATE(goal_description_type, iterator_type, context_type);
-    BOOST_SPIRIT_INSTANTIATE(connected_sentence_type, iterator_type, context_type);
+    //BOOST_SPIRIT_INSTANTIATE(connected_sentence_type, iterator_type, context_type);
 
     BOOST_SPIRIT_INSTANTIATE(domain_type, iterator_type, context_type);
     BOOST_SPIRIT_INSTANTIATE(problem_type, iterator_type, context_type);

--- a/lib/parsing/domain.cpp
+++ b/lib/parsing/domain.cpp
@@ -17,7 +17,7 @@ namespace parser {
 
     BOOST_SPIRIT_INSTANTIATE(atomic_formula_terms_type, iterator_type, context_type);
     BOOST_SPIRIT_INSTANTIATE(goal_description_type, iterator_type, context_type);
-    //BOOST_SPIRIT_INSTANTIATE(and_sentence_type, iterator_type, context_type);
+    BOOST_SPIRIT_INSTANTIATE(connected_sentence_type, iterator_type, context_type);
 
     BOOST_SPIRIT_INSTANTIATE(domain_type, iterator_type, context_type);
     BOOST_SPIRIT_INSTANTIATE(problem_type, iterator_type, context_type);

--- a/lib/parsing/domain.cpp
+++ b/lib/parsing/domain.cpp
@@ -16,8 +16,7 @@ namespace parser {
     BOOST_SPIRIT_INSTANTIATE(atomic_formula_skeleton_type, iterator_type, context_type);
 
     BOOST_SPIRIT_INSTANTIATE(atomic_formula_terms_type, iterator_type, context_type);
-    BOOST_SPIRIT_INSTANTIATE(goal_description_type, iterator_type, context_type);
-    //BOOST_SPIRIT_INSTANTIATE(connected_sentence_type, iterator_type, context_type);
+    BOOST_SPIRIT_INSTANTIATE(sentence_type, iterator_type, context_type);
 
     BOOST_SPIRIT_INSTANTIATE(domain_type, iterator_type, context_type);
     BOOST_SPIRIT_INSTANTIATE(problem_type, iterator_type, context_type);

--- a/lib/parsing/domain.hpp
+++ b/lib/parsing/domain.hpp
@@ -69,6 +69,9 @@ namespace parser {
         rule<class TAtomicFormulaTerms, ast::AtomicFormula<ast::Term>>;
     BOOST_SPIRIT_DECLARE(atomic_formula_terms_type);
 
+    using connected_sentence_type = rule<class TConnectedSentence, ast::ConnectedSentence>;
+    BOOST_SPIRIT_DECLARE(connected_sentence_type);
+
     using goal_description_type = rule<class TGoalDescription, ast::GoalDescription>;
     BOOST_SPIRIT_DECLARE(goal_description_type);
 
@@ -101,7 +104,7 @@ parser::atomic_formula_skeleton_type atomic_formula_skeleton();
 parser::atomic_formula_terms_type atomic_formula_terms();
 
 parser::goal_description_type goal_description();
-//parser::and_sentence_type and_sentence();
+parser::connected_sentence_type connected_sentence();
 parser::requirements_type requirements();
 
 parser::domain_type domain();

--- a/lib/parsing/domain.hpp
+++ b/lib/parsing/domain.hpp
@@ -69,11 +69,8 @@ namespace parser {
         rule<class TAtomicFormulaTerms, ast::AtomicFormula<ast::Term>>;
     BOOST_SPIRIT_DECLARE(atomic_formula_terms_type);
 
-    //using connected_sentence_type = rule<class TConnectedSentence, ast::ConnectedSentence>;
-    //BOOST_SPIRIT_DECLARE(connected_sentence_type);
-
-    using goal_description_type = rule<class TGoalDescription, ast::GoalDescription>;
-    BOOST_SPIRIT_DECLARE(goal_description_type);
+    using sentence_type = rule<class TSentence, ast::Sentence>;
+    BOOST_SPIRIT_DECLARE(sentence_type);
 
     using domain_type = rule<class TDomain, ast::Domain>;
     BOOST_SPIRIT_DECLARE(domain_type);
@@ -103,7 +100,7 @@ parser::typed_list_variables_type typed_list_variables();
 parser::atomic_formula_skeleton_type atomic_formula_skeleton();
 parser::atomic_formula_terms_type atomic_formula_terms();
 
-parser::goal_description_type goal_description();
+parser::sentence_type sentence();
 //parser::connected_sentence_type connected_sentence();
 parser::requirements_type requirements();
 

--- a/lib/parsing/domain.hpp
+++ b/lib/parsing/domain.hpp
@@ -69,8 +69,8 @@ namespace parser {
         rule<class TAtomicFormulaTerms, ast::AtomicFormula<ast::Term>>;
     BOOST_SPIRIT_DECLARE(atomic_formula_terms_type);
 
-    using connected_sentence_type = rule<class TConnectedSentence, ast::ConnectedSentence>;
-    BOOST_SPIRIT_DECLARE(connected_sentence_type);
+    //using connected_sentence_type = rule<class TConnectedSentence, ast::ConnectedSentence>;
+    //BOOST_SPIRIT_DECLARE(connected_sentence_type);
 
     using goal_description_type = rule<class TGoalDescription, ast::GoalDescription>;
     BOOST_SPIRIT_DECLARE(goal_description_type);
@@ -104,7 +104,7 @@ parser::atomic_formula_skeleton_type atomic_formula_skeleton();
 parser::atomic_formula_terms_type atomic_formula_terms();
 
 parser::goal_description_type goal_description();
-parser::connected_sentence_type connected_sentence();
+//parser::connected_sentence_type connected_sentence();
 parser::requirements_type requirements();
 
 parser::domain_type domain();

--- a/lib/parsing/domain_def.hpp
+++ b/lib/parsing/domain_def.hpp
@@ -97,16 +97,15 @@ namespace parser {
     auto const nil_def = '(' >> lit(")");
     BOOST_SPIRIT_DEFINE(nil);
 
-    rule<class TGoalDescriptionValue, ast::GoalDescriptionValue> goal_description_value = "goal_description_value";
     rule<class TGoalDescription, ast::GoalDescription> goal_description = "goal_description";
     rule<class TConnectedSentence, ast::ConnectedSentence> const connected_sentence = "connected_sentence";
 
     auto const connected_sentence_def = '(' >> lit("and") >> *goal_description >> ')';
-    auto const goal_description_value_def = nil | atomic_formula_terms | goal_description;
-    auto const goal_description_def = goal_description_value;
+    auto const goal_description_def = nil | atomic_formula_terms | connected_sentence;
+
+    //auto const goal_description_def = nil | atomic_formula_terms;// | connected_sentence;
 
     BOOST_SPIRIT_DEFINE(connected_sentence);
-    BOOST_SPIRIT_DEFINE(goal_description_value);
     BOOST_SPIRIT_DEFINE(goal_description);
 
 
@@ -172,7 +171,6 @@ parser::atomic_formula_terms_type atomic_formula_terms() {
 }
 
 parser::goal_description_type goal_description() { return parser::goal_description; }
-parser::connected_sentence_type connected_sentence() { return parser::connected_sentence; }
 parser::requirements_type requirements() { return parser::requirements; }
 parser::domain_type domain() { return parser::domain; }
 parser::problem_type problem() { return parser::problem; }

--- a/lib/parsing/domain_def.hpp
+++ b/lib/parsing/domain_def.hpp
@@ -84,30 +84,45 @@ namespace parser {
 
     // Term
     rule<class Term, ast::Term> const term = "term";
-    auto const term_def = name | variable;
+    auto const term_def = constant | variable;
     BOOST_SPIRIT_DEFINE(term);
 
     // Atomic formula of terms
-    rule<class TAtomicFormulaTerms, ast::AtomicFormula<ast::Term>> const atomic_formula_terms = "atomic_formula_terms";
+    rule<class TAtomicFormulaTerms, ast::AtomicFormula<ast::Term>> const
+        atomic_formula_terms = "atomic_formula_terms";
     auto const atomic_formula_terms_def = '(' >> predicate >> *term >> ')';
     BOOST_SPIRIT_DEFINE(atomic_formula_terms);
 
-    //Nil
+    // Nil
     rule<class TNil, ast::Nil> const nil = "nil";
     auto const nil_def = '(' >> lit(")");
     BOOST_SPIRIT_DEFINE(nil);
 
-    rule<class TGoalDescription, ast::GoalDescription> goal_description = "goal_description";
-    rule<class TConnectedSentence, ast::ConnectedSentence> const connected_sentence = "connected_sentence";
+    rule<class TSentence, ast::Sentence> sentence = "sentence";
 
-    auto const connected_sentence_def = '(' >> lit("and") >> *goal_description >> ')';
-    auto const goal_description_def = nil | atomic_formula_terms | connected_sentence;
+    rule<class TAndSentence, ast::AndSentence> const and_sentence =
+        "and_sentence";
+    auto const and_sentence_def = '(' >> lit("and") >> *sentence >> ')';
+    BOOST_SPIRIT_DEFINE(and_sentence);
 
-    //auto const goal_description_def = nil | atomic_formula_terms;// | connected_sentence;
+    rule<class TOrSentence, ast::OrSentence> const or_sentence = "or_sentence";
+    auto const or_sentence_def = '(' >> lit("or") >> *sentence >> ')';
+    BOOST_SPIRIT_DEFINE(or_sentence);
 
-    BOOST_SPIRIT_DEFINE(connected_sentence);
-    BOOST_SPIRIT_DEFINE(goal_description);
+    rule<class TNotSentence, ast::NotSentence> const not_sentence =
+        "not_sentence";
+    auto const not_sentence_def = '(' >> lit("not") >> sentence >> ')';
+    BOOST_SPIRIT_DEFINE(not_sentence);
 
+    rule<class TImplySentence, ast::ImplySentence> const imply_sentence =
+        "imply_sentence";
+    auto const imply_sentence_def = '(' >> lit("imply") >> sentence >> sentence
+                                    >> ')';
+    BOOST_SPIRIT_DEFINE(imply_sentence);
+
+    auto const sentence_def = nil | atomic_formula_terms | and_sentence |
+                              or_sentence | not_sentence | imply_sentence;
+    BOOST_SPIRIT_DEFINE(sentence);
 
     rule<class TTypes, TypedList<Name>> const types = "types";
     auto const types_def = '(' >> lit(":types") >> typed_list_names >> ')';
@@ -157,6 +172,7 @@ parser::variable_type variable() { return parser::variable; }
 parser::primitive_type_type primitive_type() { return parser::primitive_type; }
 parser::either_type_type either_type() { return parser::either_type; }
 parser::type_type type() { return parser::type; }
+
 parser::typed_list_names_type typed_list_names() {
     return parser::typed_list_names;
 }
@@ -170,7 +186,7 @@ parser::atomic_formula_terms_type atomic_formula_terms() {
     return parser::atomic_formula_terms;
 }
 
-parser::goal_description_type goal_description() { return parser::goal_description; }
+parser::sentence_type sentence() { return parser::sentence; }
 parser::requirements_type requirements() { return parser::requirements; }
 parser::domain_type domain() { return parser::domain; }
 parser::problem_type problem() { return parser::problem; }

--- a/lib/parsing/domain_def.hpp
+++ b/lib/parsing/domain_def.hpp
@@ -172,7 +172,7 @@ parser::atomic_formula_terms_type atomic_formula_terms() {
 }
 
 parser::goal_description_type goal_description() { return parser::goal_description; }
-//parser::connected_sentence_type connected_sentence() { return parser::connected_sentence; }
+parser::connected_sentence_type connected_sentence() { return parser::connected_sentence; }
 parser::requirements_type requirements() { return parser::requirements; }
 parser::domain_type domain() { return parser::domain; }
 parser::problem_type problem() { return parser::problem; }

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -178,10 +178,10 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     BOOST_TEST(boost::get<ast::Nil>(gd.value) == ast::Nil());
 
     // Parse atomic formula of terms
-    gd = parse<ast::GoalDescription>("(predicate name ?variable)", goal_description());
-    BOOST_TEST(boost::get<ast::AtomicFormula<ast::Term>>(gd.value).predicate.name == "predicate");
+    auto gd2 = parse<ast::GoalDescription>("(predicate name ?variable)", goal_description());
+    BOOST_TEST(boost::get<ast::AtomicFormula<ast::Term>>(gd2.value).predicate.name == "predicate");
 
-    auto as = parse<ast::GoalDescription>("(and () (predicate name ?variable))", goal_description());
+    //auto as = parse<ast::GoalDescription>("(and () (predicate name ?variable))", goal_description());
     //BOOST_TEST(boost::get<ast::AtomicFormula<ast::Term>>(gd.children[1]).args.size() == 2);
 
     storage = R"(

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     gd = parse<ast::GoalDescription>("(predicate name ?variable)", goal_description());
     BOOST_TEST(boost::get<ast::AtomicFormula<ast::Term>>(gd.value).predicate.name == "predicate");
 
-    //auto as = parse<ast::AndSentence>("(and () (predicate name ?variable))", and_sentence());
+    auto as = parse<ast::GoalDescription>("(and () (predicate name ?variable))", goal_description());
     //BOOST_TEST(boost::get<ast::AtomicFormula<ast::Term>>(gd.children[1]).args.size() == 2);
 
     storage = R"(

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     // Test type parsing
     auto t = parse<ast::Type>("type", type());
     BOOST_TEST(boost::get<ast::PrimitiveType>(t).name == "type");
-    //BOOST_TEST(boost::get<ast::PrimitiveType>(t).name == "type");
+    // BOOST_TEST(boost::get<ast::PrimitiveType>(t).name == "type");
 
     t = parse<ast::Type>("(either type0 type1)", type());
     BOOST_TEST(in(ast::PrimitiveType{"type0"},
@@ -64,9 +64,8 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     BOOST_TEST(tl.explicitly_typed_lists[0].entries[0] == "name0");
     BOOST_TEST(tl.explicitly_typed_lists[0].entries[1] == "name1");
     BOOST_TEST(tl.explicitly_typed_lists[0].entries[2] == "name2");
-    BOOST_TEST(
-        boost::get<ast::PrimitiveType>(tl.explicitly_typed_lists[0].type).name ==
-        "type");
+    BOOST_TEST(boost::get<ast::PrimitiveType>(tl.explicitly_typed_lists[0].type)
+                   .name == "type");
 
     // Test explicitly typed list with either type
     tl = parse<ast::TypedList<ast::Name>>(
@@ -87,12 +86,14 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     auto afs = parse<ast::AtomicFormulaSkeleton>(
         "(predicate ?var0 ?var1 - type0 ?var2)", atomic_formula_skeleton());
     BOOST_TEST(afs.predicate.name == "predicate");
-    BOOST_TEST(afs.args.explicitly_typed_lists[0].entries[0].name == "var0");
-    BOOST_TEST(afs.args.explicitly_typed_lists[0].entries[1].name == "var1");
-    BOOST_TEST(
-        boost::get<ast::PrimitiveType>(afs.args.explicitly_typed_lists[0].type).name ==
-        "type0");
-    BOOST_TEST(afs.args.implicitly_typed_list.value()[0].name == "var2");
+    BOOST_TEST(afs.variables.explicitly_typed_lists[0].entries[0].name ==
+               "var0");
+    BOOST_TEST(afs.variables.explicitly_typed_lists[0].entries[1].name ==
+               "var1");
+    BOOST_TEST(boost::get<ast::PrimitiveType>(
+                   afs.variables.explicitly_typed_lists[0].type)
+                   .name == "type0");
+    BOOST_TEST(afs.variables.implicitly_typed_list.value()[0].name == "var2");
 
     // Test requirements
     auto reqs = parse<vector<string>>("(:requirements :strips :typing)",
@@ -104,7 +105,7 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     auto aft = parse<ast::AtomicFormula<ast::Term>>(
         "(predicate name ?variable)", atomic_formula_terms());
     BOOST_TEST(aft.predicate.name == "predicate");
-    BOOST_TEST(boost::get<ast::Name>(aft.args[0]) == "name");
+    BOOST_TEST(boost::get<ast::Constant>(aft.args[0]).name == "name");
     BOOST_TEST(boost::get<ast::Variable>(aft.args[1]).name == "variable");
 
     storage = R"(
@@ -157,39 +158,47 @@ BOOST_AUTO_TEST_CASE(test_parser) {
     // Test constants
     BOOST_TEST(dom.constants.explicitly_typed_lists[0].entries[0] ==
                "mainsite");
-    BOOST_TEST(
-        boost::get<ast::PrimitiveType>(dom.constants.explicitly_typed_lists[0].type)
-            .name == "site");
+    BOOST_TEST(boost::get<ast::PrimitiveType>(
+                   dom.constants.explicitly_typed_lists[0].type)
+                   .name == "site");
 
     // Test parsing of predicates
     BOOST_TEST(dom.predicates.size() == 7);
     BOOST_TEST(dom.predicates[0].predicate.name == "walls-built");
     BOOST_TEST(
-        dom.predicates[0].args.explicitly_typed_lists[0].entries[0].name ==
+        dom.predicates[0].variables.explicitly_typed_lists[0].entries[0].name ==
         "s");
     BOOST_TEST(boost::get<ast::PrimitiveType>(
-                   dom.predicates[0].args.explicitly_typed_lists[0].type)
+                   dom.predicates[0].variables.explicitly_typed_lists[0].type)
                    .name == "site");
 
     // Test parsing of goal descriptions
 
     // Parse nil
-    auto gd = parse<ast::GoalDescription>("()", goal_description());
+    auto gd = parse<ast::Sentence>("()", sentence());
     BOOST_TEST(boost::get<ast::Nil>(gd) == ast::Nil());
 
     // Parse atomic formula of terms
-    auto gd2 = parse<ast::GoalDescription>("(predicate name ?variable)", goal_description());
-    BOOST_TEST(boost::get<ast::AtomicFormula<ast::Term>>(gd2).predicate.name == "predicate");
+    auto gd2 = parse<ast::Sentence>("(predicate name ?variable)", sentence());
+    auto atomic_formula_1 = boost::get<ast::AtomicFormula<ast::Term>>(gd2);
+    BOOST_TEST(atomic_formula_1.predicate.name == "predicate");
+    auto constant_1 = boost::get<ast::Constant>(atomic_formula_1.args[0]);
+    BOOST_TEST(constant_1.name == "name");
 
-    auto as = parse<ast::GoalDescription>("(and () (predicate name ?variable))", goal_description());
-    auto cs = boost::get<ast::ConnectedSentence>(as);
-    BOOST_TEST(cs.args.size() == 2);
-    BOOST_TEST(boost::get<ast::Nil>(cs.args[0]) == ast::Nil());
-    auto af = boost::get<ast::AtomicFormula<ast::Term>>(cs.args[1]);
+    // Test and sentence parsing
+    auto s =
+        parse<ast::Sentence>("(and () (predicate name ?variable))", sentence());
+    auto as = boost::get<ast::AndSentence>(s);
+    BOOST_TEST(as.sentences.size() == 2);
+    BOOST_TEST(boost::get<ast::Nil>(as.sentences[0]) == ast::Nil());
+
+    auto af = boost::get<ast::AtomicFormula<ast::Term>>(as.sentences[1]);
     BOOST_TEST(af.predicate.name == "predicate");
     BOOST_TEST(af.args.size() == 2);
-    BOOST_TEST(boost::get<string>(af.args[0]) == "name");
+    BOOST_TEST(boost::get<ast::Constant>(af.args[0]).name == "name");
     BOOST_TEST(boost::get<ast::Variable>(af.args[1]).name == "variable");
+
+    // TODO add tests for parsing or, not, imply and other complex sentences.
 
     storage = R"(
         (define


### PR DESCRIPTION
This PR implements parsing of recursive goal definitions, including sentences that have 'and', 'or', 'not', and 'imply' connectors.