### PR TITLE
Fixing nlohmann-json compilation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,5 @@ jobs:
         mkdir build
         cd build
         cmake .. 
-        # In the future, enable the other tests as well
-        make -j test_parser
-        ./test/test_parser
+        make -j
+        make test

--- a/apps/planners/domains/simple_sar.h
+++ b/apps/planners/domains/simple_sar.h
@@ -1,79 +1,84 @@
+#pragma once
+
 #include "cpphop.h"
 #include <math.h>
 #include <nlohmann/json.hpp>
 
-
 // operators
 template <class State> std::optional<State> search(State state, Args args) {
-  auto agent = args["agent"];
-  auto area = args["area"];
-  if (state.loc[agent] == area && state.time <= 590) {
-    if (state.time < 420 && (state.y_vic[area] - state.y_seen[agent]) > 0) {
-      state.y_seen[agent] = state.y_seen[agent] + 1;
+    auto agent = args["agent"];
+    auto area = args["area"];
+    if (state.loc[agent] == area && state.time <= 590) {
+        if (state.time < 420 && (state.y_vic[area] - state.y_seen[agent]) > 0) {
+            state.y_seen[agent] = state.y_seen[agent] + 1;
+        }
+
+        if ((state.g_vic[area] - state.g_seen[agent]) > 0) {
+            state.g_seen[agent] = state.g_seen[agent] + 1;
+        }
+
+        state.time = state.time + 10;
+
+        return state;
     }
-
-    if ((state.g_vic[area] - state.g_seen[agent]) > 0) {
-      state.g_seen[agent] = state.g_seen[agent] + 1;
-    } 
- 
-    state.time = state.time + 10;
-
-    return state;
-  }
-  else {
-    return std::nullopt;
-  }
+    else {
+        return std::nullopt;
+    }
 }
 
-template <class State> std::optional<State> triageGreen(State state, Args args) {
-  auto agent = args["agent"];
-  auto area = args["area"];
-  if (state.loc[agent] == area && state.g_vic[area] > 0 && state.time <= 593) {
-    state.g_seen[agent] = state.g_seen[agent] - 1;
-    state.g_vic[area] = state.g_vic[area] - 1;
-    state.g_total = state.g_total + 1; 
-    state.time = state.time + 7;
+template <class State>
+std::optional<State> triageGreen(State state, Args args) {
+    auto agent = args["agent"];
+    auto area = args["area"];
+    if (state.loc[agent] == area && state.g_vic[area] > 0 &&
+        state.time <= 593) {
+        state.g_seen[agent] = state.g_seen[agent] - 1;
+        state.g_vic[area] = state.g_vic[area] - 1;
+        state.g_total = state.g_total + 1;
+        state.time = state.time + 7;
 
-    return state;
-  }
-  else {
-    return std::nullopt;
-  }
+        return state;
+    }
+    else {
+        return std::nullopt;
+    }
 }
 
-template <class State> std::optional<State> triageYellow(State state, Args args) {
-  auto agent = args["agent"];
-  auto area = args["area"];
-  if (state.loc[agent] == area && state.y_vic[area] > 0 && state.time <= 405) {
-    state.y_seen[agent] = state.y_seen[agent] - 1;
-    state.y_vic[area] = state.y_vic[area] - 1;
-    state.y_total = state.y_total + 1; 
-    state.time = state.time + 15;
+template <class State>
+std::optional<State> triageYellow(State state, Args args) {
+    auto agent = args["agent"];
+    auto area = args["area"];
+    if (state.loc[agent] == area && state.y_vic[area] > 0 &&
+        state.time <= 405) {
+        state.y_seen[agent] = state.y_seen[agent] - 1;
+        state.y_vic[area] = state.y_vic[area] - 1;
+        state.y_total = state.y_total + 1;
+        state.time = state.time + 15;
 
-    return state;
-  }
-  else {
-    return std::nullopt;
-  }
+        return state;
+    }
+    else {
+        return std::nullopt;
+    }
 }
 
 template <class State> std::optional<State> move(State state, Args args) {
-  auto agent = args["agent"];
-  auto c_area = args["c_area"];
-  auto n_area = args["n_area"];
-  if (state.loc[agent] == c_area && state.time <= 590) {
-    state.loc[agent] = n_area;
-    state.y_seen[agent] = 0;
-    state.g_seen[agent] = 0;
-    
-    state.visited["me"].push_back(n_area);
-    state.time = state.time + 10;
+    auto agent = args["agent"];
+    auto c_area = args["c_area"];
+    auto n_area = args["n_area"];
+    if (state.loc[agent] == c_area && state.time <= 590) {
+        state.loc[agent] = n_area;
+        state.y_seen[agent] = 0;
+        state.g_seen[agent] = 0;
 
-    return state;
-  }
-  else {
-    return std::nullopt;
-  }
+        state.visited["me"].push_back(n_area);
+        state.time = state.time + 10;
+
+        return state;
+    }
+    else {
+        return std::nullopt;
+    }
 }
 
 template <class State> std::optional<State> exit(State state, Args args) {
@@ -82,258 +87,282 @@ template <class State> std::optional<State> exit(State state, Args args) {
 
 // Methods
 template <class State> bTasks explore_left_to_right(State state, Args args) {
-  auto agent = args["agent"];
-  return {true, 
-    {Task("explore_left_region",Args({{"agent",agent}})),
-     Task("explore_mid_region",Args({{"agent",agent}})),
-     Task("explore_right_region",Args({{"agent",agent}})),
-     Task("exit",Args({}))}}; 
+    auto agent = args["agent"];
+    return {true,
+            {Task("explore_left_region", Args({{"agent", agent}})),
+             Task("explore_mid_region", Args({{"agent", agent}})),
+             Task("explore_right_region", Args({{"agent", agent}})),
+             Task("exit", Args({}))}};
 }
 
 template <class State> bTasks explore_right_to_left(State state, Args args) {
-  auto agent = args["agent"];
-  return {true, 
-    {Task("explore_right_region",Args({{"agent",agent}})),
-     Task("explore_mid_region",Args({{"agent",agent}})),
-     Task("explore_left_region",Args({{"agent",agent}})),
-     Task("exit",Args({}))}}; 
+    auto agent = args["agent"];
+    return {true,
+            {Task("explore_right_region", Args({{"agent", agent}})),
+             Task("explore_mid_region", Args({{"agent", agent}})),
+             Task("explore_left_region", Args({{"agent", agent}})),
+             Task("exit", Args({}))}};
 }
 
 template <class State> bTasks explore_mid_left_right(State state, Args args) {
-  auto agent = args["agent"];
-  return {true, 
-    {Task("explore_mid_region",Args({{"agent",agent}})),
-     Task("explore_left_region",Args({{"agent",agent}})),
-     Task("explore_right_region",Args({{"agent",agent}})),
-     Task("exit",Args({}))}}; 
+    auto agent = args["agent"];
+    return {true,
+            {Task("explore_mid_region", Args({{"agent", agent}})),
+             Task("explore_left_region", Args({{"agent", agent}})),
+             Task("explore_right_region", Args({{"agent", agent}})),
+             Task("exit", Args({}))}};
 }
 
 template <class State> bTasks explore_mid_right_left(State state, Args args) {
-  auto agent = args["agent"];
-  return {true, 
-    {Task("explore_mid_region",Args({{"agent",agent}})),
-     Task("explore_right_region",Args({{"agent",agent}})),
-     Task("explore_left_region",Args({{"agent",agent}})),
-     Task("exit",Args({}))}}; 
+    auto agent = args["agent"];
+    return {true,
+            {Task("explore_mid_region", Args({{"agent", agent}})),
+             Task("explore_right_region", Args({{"agent", agent}})),
+             Task("explore_left_region", Args({{"agent", agent}})),
+             Task("exit", Args({}))}};
 }
 
 template <class State> bTasks search_left(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 590 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("search",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_left_region",Args({{"agent",agent}}))}};
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 590 && state.loc[agent] != "entrance") {
+        return {true,
+                {Task("search",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_left_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks triageGreen_left(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 590 && state.g_seen[agent] > 0 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("triageGreen",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_left_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 590 && state.g_seen[agent] > 0 &&
+        state.loc[agent] != "entrance") {
+        return {true,
+                {Task("triageGreen",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_left_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks triageYellow_left(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 405 && state.y_seen[agent] > 0 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("triageYellow",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_left_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 405 && state.y_seen[agent] > 0 &&
+        state.loc[agent] != "entrance") {
+        return {true,
+                {Task("triageYellow",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_left_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks move_left(State state, Args args) {
-  auto agent = args["agent"];
-  std::string n_area = "none";
-  for(auto a : state.left_region) {
-    if (!in(a,state.visited[agent])) {
-      n_area = a;
-      break;
+    auto agent = args["agent"];
+    std::string n_area = "none";
+    for (auto a : state.left_region) {
+        if (!in(a, state.visited[agent])) {
+            n_area = a;
+            break;
+        }
     }
-  }
-  if (state.time <= 590 && n_area != "none") {
-    return {true, 
-      {Task("move",Args({{"agent",agent},{"c_area",state.loc[agent]},{"n_area",n_area}})),
-      Task("explore_left_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    if (state.time <= 590 && n_area != "none") {
+        return {true,
+                {Task("move",
+                      Args({{"agent", agent},
+                            {"c_area", state.loc[agent]},
+                            {"n_area", n_area}})),
+                 Task("explore_left_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks leave_left(State state, Args args) {
-  auto agent = args["agent"];
-  bool explored = true;
-  for(auto a : state.left_region) {
-    if (!in(a,state.visited[agent])) {
-      explored = false;
-      break;
+    auto agent = args["agent"];
+    bool explored = true;
+    for (auto a : state.left_region) {
+        if (!in(a, state.visited[agent])) {
+            explored = false;
+            break;
+        }
     }
-  }
- 
-  if (state.time > 590 || explored) {
-    return {true,{}}; 
-  }
-  else {
-    return {false,{}};
-  }
+
+    if (state.time > 590 || explored) {
+        return {true, {}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks search_right(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 590 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("search",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_right_region",Args({{"agent",agent}}))}};
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 590 && state.loc[agent] != "entrance") {
+        return {true,
+                {Task("search",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_right_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks triageGreen_right(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 590 && state.g_seen[agent] > 0 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("triageGreen",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_right_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 590 && state.g_seen[agent] > 0 &&
+        state.loc[agent] != "entrance") {
+        return {true,
+                {Task("triageGreen",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_right_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks triageYellow_right(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 405 && state.y_seen[agent] > 0 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("triageYellow",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_right_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 405 && state.y_seen[agent] > 0 &&
+        state.loc[agent] != "entrance") {
+        return {true,
+                {Task("triageYellow",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_right_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks move_right(State state, Args args) {
-  auto agent = args["agent"];
-  std::string n_area = "none";
-  for(auto a : state.right_region) {
-    if (!in(a,state.visited[agent])) {
-      n_area = a;
-      break;
+    auto agent = args["agent"];
+    std::string n_area = "none";
+    for (auto a : state.right_region) {
+        if (!in(a, state.visited[agent])) {
+            n_area = a;
+            break;
+        }
     }
-  }
-  if (state.time <= 590 && n_area != "none") {
-    return {true, 
-      {Task("move",Args({{"agent",agent},{"c_area",state.loc[agent]},{"n_area",n_area}})),
-      Task("explore_right_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    if (state.time <= 590 && n_area != "none") {
+        return {true,
+                {Task("move",
+                      Args({{"agent", agent},
+                            {"c_area", state.loc[agent]},
+                            {"n_area", n_area}})),
+                 Task("explore_right_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks leave_right(State state, Args args) {
-  auto agent = args["agent"];
-  bool explored = true;
-  for(auto a : state.right_region) {
-    if (!in(a,state.visited[agent])) {
-      explored = false;
-      break;
+    auto agent = args["agent"];
+    bool explored = true;
+    for (auto a : state.right_region) {
+        if (!in(a, state.visited[agent])) {
+            explored = false;
+            break;
+        }
     }
-  }
- 
-  if (state.time > 590 || explored) {
-    return {true,{}}; 
-  }
-  else {
-    return {false,{}};
-  }
+
+    if (state.time > 590 || explored) {
+        return {true, {}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks search_mid(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 590 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("search",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_mid_region",Args({{"agent",agent}}))}};
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 590 && state.loc[agent] != "entrance") {
+        return {true,
+                {Task("search",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_mid_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks triageGreen_mid(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 590 && state.g_seen[agent] > 0 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("triageGreen",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_mid_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 590 && state.g_seen[agent] > 0 &&
+        state.loc[agent] != "entrance") {
+        return {true,
+                {Task("triageGreen",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_mid_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks triageYellow_mid(State state, Args args) {
-  auto agent = args["agent"];
-  if (state.time <= 405 && state.y_seen[agent] > 0 && state.loc[agent] != "entrance") {
-    return {true, 
-      {Task("triageYellow",Args({{"agent",agent},{"area",state.loc[agent]}})),
-      Task("explore_mid_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    auto agent = args["agent"];
+    if (state.time <= 405 && state.y_seen[agent] > 0 &&
+        state.loc[agent] != "entrance") {
+        return {true,
+                {Task("triageYellow",
+                      Args({{"agent", agent}, {"area", state.loc[agent]}})),
+                 Task("explore_mid_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks move_mid(State state, Args args) {
-  auto agent = args["agent"];
-  std::string n_area = "none";
-  for(auto a : state.mid_region) {
-    if (!in(a,state.visited[agent])) {
-      n_area = a;
-      break;
+    auto agent = args["agent"];
+    std::string n_area = "none";
+    for (auto a : state.mid_region) {
+        if (!in(a, state.visited[agent])) {
+            n_area = a;
+            break;
+        }
     }
-  }
-  if (state.time <= 590 && n_area != "none") {
-    return {true, 
-      {Task("move",Args({{"agent",agent},{"c_area",state.loc[agent]},{"n_area",n_area}})),
-      Task("explore_mid_region",Args({{"agent",agent}}))}}; 
-  }
-  else {
-    return {false,{}};
-  }
+    if (state.time <= 590 && n_area != "none") {
+        return {true,
+                {Task("move",
+                      Args({{"agent", agent},
+                            {"c_area", state.loc[agent]},
+                            {"n_area", n_area}})),
+                 Task("explore_mid_region", Args({{"agent", agent}}))}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 template <class State> bTasks leave_mid(State state, Args args) {
-  auto agent = args["agent"];
-  bool explored = true;
-  for(auto a : state.mid_region) {
-    if (!in(a,state.visited[agent])) {
-      explored = false;
-      break;
+    auto agent = args["agent"];
+    bool explored = true;
+    for (auto a : state.mid_region) {
+        if (!in(a, state.visited[agent])) {
+            explored = false;
+            break;
+        }
     }
-  }
- 
-  if (state.time > 590 || explored) {
-    return {true,{}}; 
-  }
-  else {
-    return {false,{}};
-  }
+
+    if (state.time > 590 || explored) {
+        return {true, {}};
+    }
+    else {
+        return {false, {}};
+    }
 }
 
 class SARState {
@@ -351,53 +380,46 @@ class SARState {
     std::vector<std::string> right_region;
     std::vector<std::string> mid_region;
     int time;
-    std::unordered_map<std::string, std::vector<std::string>> visited; 
+    std::unordered_map<std::string, std::vector<std::string>> visited;
 
-    friend bool operator== (SARState & lhs, SARState & rhs) {
-      return (
-             lhs.loc == rhs.loc && 
-             lhs.y_vic == rhs.y_vic &&
-             lhs.g_vic == rhs.g_vic &&
-             lhs.y_total == rhs.y_total &&
-             lhs.g_total == rhs.g_total &&
-             lhs.y_seen == rhs.y_seen &&
-             lhs.g_seen == rhs.g_seen &&
-             lhs.left_region == rhs.left_region &&
-             lhs.right_region == rhs.right_region &&
-             lhs.mid_region == rhs.mid_region &&
-             lhs.time == rhs.time &&
-             lhs.visited == rhs.visited &&
-             lhs.y_max == rhs.y_max &&
-             lhs.g_max == rhs.g_max
-          );
+    friend bool operator==(SARState& lhs, SARState& rhs) {
+        return (lhs.loc == rhs.loc && lhs.y_vic == rhs.y_vic &&
+                lhs.g_vic == rhs.g_vic && lhs.y_total == rhs.y_total &&
+                lhs.g_total == rhs.g_total && lhs.y_seen == rhs.y_seen &&
+                lhs.g_seen == rhs.g_seen &&
+                lhs.left_region == rhs.left_region &&
+                lhs.right_region == rhs.right_region &&
+                lhs.mid_region == rhs.mid_region && lhs.time == rhs.time &&
+                lhs.visited == rhs.visited && lhs.y_max == rhs.y_max &&
+                lhs.g_max == rhs.g_max);
     }
     void set_max_vic() {
-      g_max = 0;
-      for (auto i = g_vic.begin(); i != g_vic.end(); ++i) {
-        g_max += i->second;
-      }
+        g_max = 0;
+        for (auto i = g_vic.begin(); i != g_vic.end(); ++i) {
+            g_max += i->second;
+        }
 
-      y_max = 0;
-      for (auto i = y_vic.begin(); i != y_vic.end(); ++i) {
-        y_max += i->second;
-      }
+        y_max = 0;
+        for (auto i = y_vic.begin(); i != y_vic.end(); ++i) {
+            y_max += i->second;
+        }
     }
 
-    json to_json() {
-      return json{{"loc", this->loc},
-               {"y_vic",this->y_vic},
-               {"g_vic",this->g_vic},
-               {"y_total",this->y_total},
-               {"g_total",this->g_total},
-               {"y_seen",this->y_seen},
-               {"g_seen",this->g_seen},
-               {"left_region",this->left_region},
-               {"right_region",this->right_region},
-               {"mid_region",this->mid_region},
-               {"time",this->time},
-               {"visited",this->visited},
-               {"y_max",this->y_max},
-               {"g_max",this->g_max}};
+    nlohmann::json to_json() {
+        return nlohmann::json{{"loc", this->loc},
+                              {"y_vic", this->y_vic},
+                              {"g_vic", this->g_vic},
+                              {"y_total", this->y_total},
+                              {"g_total", this->g_total},
+                              {"y_seen", this->y_seen},
+                              {"g_seen", this->g_seen},
+                              {"left_region", this->left_region},
+                              {"right_region", this->right_region},
+                              {"mid_region", this->mid_region},
+                              {"time", this->time},
+                              {"visited", this->visited},
+                              {"y_max", this->y_max},
+                              {"g_max", this->g_max}};
     }
 };
 
@@ -407,54 +429,53 @@ class SARSelector {
     int sims = 0;
 
     double selectFunc(int pSims, double c, int r_l, int r_t) {
-      return this->mean + ((c*r_l)/r_t)*sqrt(log(pSims)/this->sims);
+        return this->mean + ((c * r_l) / r_t) * sqrt(log(pSims) / this->sims);
     }
 
     double rewardFunc(SARState s) {
-      return (50.00*s.y_total + 10.00*s.g_total)/(50.00*s.y_max + 10.00*s.g_max);
+        return (50.00 * s.y_total + 10.00 * s.g_total) /
+               (50.00 * s.y_max + 10.00 * s.g_max);
     }
-
 };
 
 class SARDomain {
   public:
-    Operators<SARState> operators = 
-      Operators<SARState>({{"search",search},
-                           {"triageGreen",triageGreen},
-                           {"triageYellow",triageYellow},
-                           {"move",move},
-                           {"exit",exit}});
+    Operators<SARState> operators =
+        Operators<SARState>({{"search", search},
+                             {"triageGreen", triageGreen},
+                             {"triageYellow", triageYellow},
+                             {"move", move},
+                             {"exit", exit}});
 
-    Methods<SARState> methods =
-      Methods<SARState>({{"SAR",
-                          {explore_left_to_right,
-                           explore_right_to_left,
-                           explore_mid_left_right,
-                           explore_mid_right_left}},
-                         {"explore_left_region",
-                          {search_left,
-                           triageYellow_left,
-                           triageGreen_left,
-                           move_left,
-                           leave_left}},
-                         {"explore_right_region",
-                          {search_right,
-                           triageYellow_right,
-                           triageGreen_right,
-                           move_right,
-                           leave_right}},
-                         {"explore_mid_region",
-                          {search_mid,
-                           triageYellow_mid,
-                           triageGreen_mid,
-                           move_mid,
-                           leave_mid}}});
+    Methods<SARState> methods = Methods<SARState>({{"SAR",
+                                                    {explore_left_to_right,
+                                                     explore_right_to_left,
+                                                     explore_mid_left_right,
+                                                     explore_mid_right_left}},
+                                                   {"explore_left_region",
+                                                    {search_left,
+                                                     triageYellow_left,
+                                                     triageGreen_left,
+                                                     move_left,
+                                                     leave_left}},
+                                                   {"explore_right_region",
+                                                    {search_right,
+                                                     triageYellow_right,
+                                                     triageGreen_right,
+                                                     move_right,
+                                                     leave_right}},
+                                                   {"explore_mid_region",
+                                                    {search_mid,
+                                                     triageYellow_mid,
+                                                     triageGreen_mid,
+                                                     move_mid,
+                                                     leave_mid}}});
 
     SARDomain() {
-      std::cout << "Operators: ";
-      print(this->operators);
+        std::cout << "Operators: ";
+        print(this->operators);
 
-      std::cout << "Method: ";
-      print(this->methods);
+        std::cout << "Method: ";
+        print(this->methods);
     };
 };

--- a/apps/planners/domains/simple_sar.h
+++ b/apps/planners/domains/simple_sar.h
@@ -2,8 +2,6 @@
 #include <math.h>
 #include <nlohmann/json.hpp>
 
-using json = nlohmann::ordered_json;
-
 
 // operators
 template <class State> std::optional<State> search(State state, Args args) {

--- a/lib/CNF.h
+++ b/lib/CNF.h
@@ -9,7 +9,6 @@ namespace ast {
 
         std::vector<Clause> clauses = {};
         Sentence operator()(Nil s) const { return s; }
-        Sentence operator()(AtomicFormula<Term> s) const { return s; }
         Sentence operator()(Literal<Term> s) const { return s; }
         Sentence operator()(AndSentence s) const { return s; }
         Sentence operator()(OrSentence s) const {

--- a/lib/cpphop/cpphop.h
+++ b/lib/cpphop/cpphop.h
@@ -14,8 +14,6 @@
 #include "printing.h"
 #include <nlohmann/json.hpp>
 
-using json = nlohmann::ordered_json;
-
 template <class State, class Domain>
 bTasks seek_plan(State state,
                  std::vector<Task> tasks,

--- a/lib/cpphop/cpphop.h
+++ b/lib/cpphop/cpphop.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "../util.h"
+#include "Node.h"
+#include "Tree.h"
+#include "printing.h"
 #include <any>
 #include <iostream>
 #include <optional>
@@ -8,11 +12,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include "Node.h"
-#include "Tree.h"
-#include "../util.h"
-#include "printing.h"
-#include <nlohmann/json.hpp>
 
 template <class State, class Domain>
 bTasks seek_plan(State state,
@@ -303,7 +302,8 @@ Tree<State, Selector> seek_planMCTS(Tree<State, Selector> t,
                                     int seed) {
     if (t[v].tasks.size() == 0) {
         t[boost::graph_bundle].plans.push_back(t[v].plan);
-        std::cout << "Plan found at depth " << t[v].depth << " and score of " << t[v].selector.rewardFunc(t[v].state) << std::endl;
+        std::cout << "Plan found at depth " << t[v].depth << " and score of "
+                  << t[v].selector.rewardFunc(t[v].state) << std::endl;
         std::cout << std::endl;
         std::cout << "Final State:" << std::endl;
         std::cout << t[v].state.to_json() << std::endl;
@@ -355,13 +355,13 @@ Tree<State, Selector> seek_planMCTS(Tree<State, Selector> t,
 }
 
 template <class State, class Domain, class Selector>
-std::pair<Tree<State,Selector>,int> cpphopMCTS(State state,
-                  Tasks tasks,
-                  Domain domain,
-                  Selector selector,
-                  double c,
-                  int r,
-                  int seed = 2021) {
+std::pair<Tree<State, Selector>, int> cpphopMCTS(State state,
+                                                 Tasks tasks,
+                                                 Domain domain,
+                                                 Selector selector,
+                                                 double c,
+                                                 int r,
+                                                 int seed = 2021) {
     Tree<State, Selector> t;
     Node<State, Selector> root;
     root.state = state;
@@ -377,5 +377,5 @@ std::pair<Tree<State,Selector>,int> cpphopMCTS(State state,
     t = seek_planMCTS(t, v, domain, selector, c, r, seed);
     std::cout << "Plan:" << std::endl;
     print(t[boost::graph_bundle].plans.back());
-    return std::make_pair(t,v);
+    return std::make_pair(t, v);
 }

--- a/lib/cpphop/plan_trace.h
+++ b/lib/cpphop/plan_trace.h
@@ -7,8 +7,6 @@
 #include <iostream>
 #include <fstream>
 
-using json = nlohmann::ordered_json;
-
 struct json_node {
   json node;
   int id;

--- a/lib/cpphop/plan_trace.h
+++ b/lib/cpphop/plan_trace.h
@@ -1,86 +1,93 @@
 #pragma once
-#include <nlohmann/json.hpp>
-#include "Tree.h"
-#include "Node.h"
+
 #include "../util.h"
+#include "Node.h"
+#include "Tree.h"
+#include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
+#include <nlohmann/json.hpp>
 
 struct json_node {
-  json node;
-  int id;
+    nlohmann::json node;
+    int id;
 };
 
-//All of these are specifically made for MCTS algorithm
-template<class State, class Selector> 
-json_node gptt(Tree<State,Selector> t, int v) {
-  json j;
+// All of these are specifically made for MCTS algorithm
+template <class State, class Selector>
+json_node gptt(Tree<State, Selector> t, int v) {
+    nlohmann::json j;
 
-  j["task"] = task2string(t[v].tasks.back());
-  j["state"] = t[v].state.to_json();
+    j["task"] = task2string(t[v].tasks.back());
+    j["state"] = t[v].state.to_json();
 
-  int w = t[v].successors.back();
+    int w = t[v].successors.back();
 
-  if (t[w].tasks.size() < t[v].tasks.size()) {
-    j["children"] = R"([])"_json;
+    if (t[w].tasks.size() < t[v].tasks.size()) {
+        j["children"] = R"([])"_json;
+        json_node n;
+        n.node = j;
+        n.id = w;
+        return n;
+    }
+    int r = (t[w].tasks.size() - t[v].tasks.size()) + 1;
+    for (int i = 0; i < r; i++) {
+        auto temp = gptt(t, w);
+        j["children"].push_back(temp.node);
+        w = temp.id;
+    }
+
     json_node n;
     n.node = j;
     n.id = w;
-    return n; 
-  }
-  int r = (t[w].tasks.size() - t[v].tasks.size()) + 1;
-  for (int i = 0; i < r; i++) {
-   auto temp = gptt(t,w);
-   j["children"].push_back(temp.node);
-   w = temp.id;
-  }
-  
-  json_node n;
-  n.node = j;
-  n.id = w;
-  return n;
+    return n;
 }
 
-template<class State, class Selector>
-json generate_plan_trace_tree(Tree<State,Selector> t, int v, bool gen_file = false, std::string outfile = "plan_trace_tree.json") {
-  auto g = gptt(t,v);
-  g.node["Final State"] = t[g.id].state.to_json();
-  if (gen_file) {
-    std::ofstream o(outfile);
-    o << std::setw(4) << g.node << std::endl;
-  }
-  return g.node;
+template <class State, class Selector>
+nlohmann::json
+generate_plan_trace_tree(Tree<State, Selector> t,
+                         int v,
+                         bool gen_file = false,
+                         std::string outfile = "plan_trace_tree.json") {
+    auto g = gptt(t, v);
+    g.node["Final State"] = t[g.id].state.to_json();
+    if (gen_file) {
+        std::ofstream o(outfile);
+        o << std::setw(4) << g.node << std::endl;
+    }
+    return g.node;
 }
 
-template<class State, class Selector>
-json gpt(Tree<State,Selector> t, int v, json j) {
-  int w = t[v].successors.back();
-  if (t[w].tasks.size() < t[v].tasks.size()) {
-    json g;
-    g["task"] = task2string(t[v].tasks.back());
-    g["state"] = t[v].state.to_json();
-    j.push_back(g);
-  }
+template <class State, class Selector>
+nlohmann::json gpt(Tree<State, Selector> t, int v, nlohmann::json j) {
+    int w = t[v].successors.back();
+    if (t[w].tasks.size() < t[v].tasks.size()) {
+        nlohmann::json g;
+        g["task"] = task2string(t[v].tasks.back());
+        g["state"] = t[v].state.to_json();
+        j.push_back(g);
+    }
 
-  if (t[w].successors.empty()) {
-    json g;
-    g["Final State"] = t[w].state.to_json();
-    j.push_back(g);
-    return j;
-  }
+    if (t[w].successors.empty()) {
+        nlohmann::json g;
+        g["Final State"] = t[w].state.to_json();
+        j.push_back(g);
+        return j;
+    }
 
-  return gpt(t,w,j); 
-
+    return gpt(t, w, j);
 }
 
-template<class State, class Selector>
-json generate_plan_trace(Tree<State,Selector> t, int v, bool gen_file = false, std::string outfile = "plan_trace.json") {
-  json j;
-  auto g = gpt(t,v,j);
-  if (gen_file) {
-    std::ofstream o(outfile);
-    o << std::setw(4) << g << std::endl;
-  }
-  return g;
+template <class State, class Selector>
+nlohmann::json generate_plan_trace(Tree<State, Selector> t,
+                                   int v,
+                                   bool gen_file = false,
+                                   std::string outfile = "plan_trace.json") {
+    nlohmann::json j;
+    auto g = gpt(t, v, j);
+    if (gen_file) {
+        std::ofstream o(outfile);
+        o << std::setw(4) << g << std::endl;
+    }
+    return g;
 }

--- a/test/test_MCTS_planner.cpp
+++ b/test/test_MCTS_planner.cpp
@@ -8,7 +8,7 @@
 #include <nlohmann/json.hpp>
 #include "plan_trace.h"
 
-using json = nlohmann::ordered_json;
+using json = nlohmann::json;
 
 BOOST_AUTO_TEST_CASE(test_MCTS_planner) {
   auto state1 = SARState();


### PR DESCRIPTION
This PR fixes compilation issues with an older version of nlohmann-json on the Github Actions Ubuntu runner than was available on MacPorts. It also removes `using` directives from header files, and applies autoformatting using `clang-format`. All the tests are now built and run on each commit, not just the parser tests.